### PR TITLE
docs: capture rendering roadmap gaps

### DIFF
--- a/docs/plans/rasterizer-v2.md
+++ b/docs/plans/rasterizer-v2.md
@@ -16,4 +16,4 @@ closed epic:
 - render-graph-owned AOV, depth, motion-vector, and temporal resources:
   `docs/plans/render-graph.md`;
 - future anti-aliasing, transparency, conservative rasterization, and material
-  graph work: `docs/roadmap.md` §4.1.b and §4.3.
+  graph work: `docs/roadmap.md` §4.1.c and §4.3.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -242,15 +242,15 @@ Beyond the existing `Raytracer`, factor in (in suggested order):
   - ~~**Material-sidedness follow-up** — connect material intent to the rasterizer's default cull mode instead of relying only on caller configuration.~~ ✅ **Done.** Front-sided materials default to backface culling, back-sided materials default to frontface culling, and two-sided materials keep both faces unless the caller sets an explicit cull mode.
   - **Texture/material input expansion** — ~~expand the material input path toward image textures, tangent frames, normal maps, and MIP-mapping~~ ✅ **Done.** Raster material evaluation now supports direct image-texture sampling with nearest/bilinear/mipmapped filtering, UV-gradient mip selection, and tangent-space normal maps derived from triangle UVs. Still TODO: bump/displacement, anisotropic filtering, cross-engine shading-normal slots, and material-graph inputs shared with the ray/path tracers.
   - ~~**Tile-parallel performance follow-up** — decide whether the engine needs an automatic tiling heuristic, coarser per-tile work, tile-local depth/color storage with a final stitch, a GPU path, or a scene where shading cost dwarfs tessellation/binning/task/cache overhead.~~ ✅ **Done for the CPU default policy.** Benchmarks now expose projected triangle count, projected bounds, tile-list duplication, framebuffer size, worker count, queue size, and MSAA samples; the default rasterizer uses those signals to select tiled rendering only for measured win cases while preserving explicit `setQueueSize(...)` / `rendercli --queue_size` overrides. Future work remains under broader performance/GPU planning.
-  - **Rasterizer anti-aliasing follow-up** — MSAA now exists for coverage/depth and resolve. ~~Next, decide whether to add centroid/per-fragment shading for cheaper MSAA previews~~ ✅ **Done.** `MSAAShadingMode::PerFragment` caches the first passing shaded color per triangle/pixel while leaving coverage/depth/stencil per sample. Next, move into the shared sample-pattern/filter API, post-process AA, TAA, alpha-to-coverage, and conservative rasterization from §4.1.b.
+  - **Rasterizer anti-aliasing follow-up** — MSAA now exists for coverage/depth and resolve. ~~Next, decide whether to add centroid/per-fragment shading for cheaper MSAA previews~~ ✅ **Done.** `MSAAShadingMode::PerFragment` caches the first passing shaded color per triangle/pixel while leaving coverage/depth/stencil per sample. Next, move into the shared sample-pattern/filter API, post-process AA, TAA, alpha-to-coverage, and conservative rasterization from §4.1.c.
   - **Frustum-culling integration** — ~~feed the rasterizer from a frustum-cull-friendly view of the current composite scene rather than traversing every tessellated mesh every frame~~ ✅ **Done.** `Primitive::forEachLeafInBounds(...)` lets the rasterizer reject bounded composite groups before leaf flattening and tessellation. A future §R7 `SpatialIndex` can replace the composite-backed view with a real acceleration tree.
   - **Rendered-doc engine parity backlog** — keep class-level rendered docs honest about which engines can support each scene. Remaining deferred coverage is explicit: `Ring`, `Union`, `Intersection`, `Difference`, `MinkowskiSum`, `ConvexHull`, and the CSG-heavy `ScriptedSurface` scenes stay raytracer-only until mesh booleans / useful scripted tessellation exist; `FishEyeCamera`, `SphericalCamera`, and `EquirectangularCamera` stay raytracer-only until they expose forward projection APIs for Rasterizer and Wireframe; ~~`ThinLensCamera` and `TiltShiftCamera` stay raytracer-only until they expose forward projection APIs for Rasterizer and Wireframe~~ ✅ **Done.** They now expose pinhole-compatible projection fallback for Rasterizer and Wireframe previews while DOF/tilt effects remain raytracer-only; material docs skip Wireframe because it ignores material shading.
   - **Rasterized shadows** — ~~add a shadow-map renderer on top of the depth/stencil path: directional-light shadow maps first~~ ✅ **Done.** `Rasterizer` now has opt-in directional-light shadow maps with `rendercli`, Modeler render-dialog controls, a Modeler live-preview shadow toggle, PCF/PCSS filtering, slope-scaled bias, practical cascade split blending, light-space cascade fitting, texel-grid-stabilized 1-4 cascades, rendered comparison sweeps, an interactive light-depth-map widget, and an interactive cascade-split widget. Cascade split diagnostics stay in the docs/widget surface until Modeler has a broader debug-overlay or multi-view framework.
   - **Planar reflections and portals** — classic stencil/pass-graph use case: mark a mirror/portal surface, render a reflected or redirected view only through that mask, clip against the portal/mirror plane, then composite. This gives raster/GPU previews good parity for flat mirrors, water planes, polished floors, and portal screens without pretending arbitrary recursive reflection is a raster strength.
 - **OpenGL viewport.** Real-time editor view. Tessellated meshes feed VBOs; GLSL shaders mirror the material library for live preview parity. Also unlocks gizmo rendering.
 - **WebGL / WebGPU preview.** The same scene rendered in a browser, served alongside the GitHub Pages docs. WebGL first (broadest support, simpler), WebGPU as a follow-up. Static-scene preview is the v1 target; web preview of *animations* (timeline scrubbing in the browser) is a stretch goal that lands after §4.7. This engine doubles as the canvas for the §4.0 interactive diagrams — the rendering engine and the explainer engine are the same code path.
-- **Path tracer.** Monte Carlo integrator over the same scene graph. Multiple Importance Sampling between BSDF sampling and light sampling. Stratified or Sobol QMC sampling. Adaptive sampling per tile. ~~SoA ray packets (`Ray4`/`Ray8`) and a first batched sphere intersection kernel for CPU packet traversal.~~ ✅ **Done.** Added aligned packet transport, primitive packet entry points with scalar fallback, and an SSE `Sphere::intersectPacket(Ray4)` proof kernel for Epic #141 / Phase 4.1; block-batched BVH traversal remains a follow-up.
-- **GPU backends, eventually.** Vulkan compute, OptiX, or Metal. Templated math primitives port reasonably to CUDA. Massive undertaking; not a near-term priority.
+- **Path tracer.** Monte Carlo integrator over the same scene graph. Multiple Importance Sampling between BSDF sampling and light sampling. Stratified or Sobol QMC sampling. Adaptive sampling per tile. The implementation should explicitly compare **megakernel**, **wavefront/queue-based**, and **material-sorted** architectures: a simple megakernel is the clearest CPU baseline, while wavefront queues expose GPU divergence, occupancy, compaction, and BSDF/light sorting tradeoffs. ~~SoA ray packets (`Ray4`/`Ray8`) and a first batched sphere intersection kernel for CPU packet traversal.~~ ✅ **Done.** Added aligned packet transport, primitive packet entry points with scalar fallback, and an SSE `Sphere::intersectPacket(Ray4)` proof kernel for Epic #141 / Phase 4.1; block-batched BVH traversal remains a follow-up.
+- **GPU backends, eventually.** Vulkan compute, OptiX, or Metal. Templated math primitives port reasonably to CUDA. Massive undertaking; not a near-term priority. When this graduates from aspiration to plan, include mesh/task shaders, bindless resource models, shader-language targets (GLSL/HLSL/WGSL/SPIR-V), and CPU/GPU residency rules for out-of-core scenes rather than treating "GPU" as only a faster execution device.
 
 The "all engines over one scene" property is itself the pedagogical payoff — being able to render a single test scene through wireframe, software raster, OpenGL, WebGL, raytracer, and path tracer side-by-side teaches more about the rendering equation than any single engine ever could.
 
@@ -302,7 +302,19 @@ Implementation order:
 
 This pass graph is the bridge between renderer parity and composability. It lets the rasterizer and future GPU rasterizer preview the parts they can approximate, while still delegating specific expensive or truth-critical work to raytracing/path tracing.
 
-#### 4.1.b Anti-aliasing and raster quality
+#### 4.1.b Renderer architecture patterns
+
+Engine implementations should be compared as algorithms in their own right, not hidden behind a single `render()` call:
+
+- **Megakernel path tracing** — one straightforward recursive/iterative kernel owns most path state; best for readability and CPU-first pedagogy, worst for GPU divergence.
+- **Wavefront path tracing** — queues for ray generation, intersections, material evaluation, shadow rays, medium sampling, and compaction; teaches GPU scheduling, occupancy, and data-oriented transport.
+- **Material/light sorted queues** — batch shading work by BSDF, texture set, or light to improve coherence; useful on both CPU SIMD and GPU.
+- **Tiled, scanline, packet, and streaming execution** — contrast image-space decomposition with ray/path queues and ray packets.
+- **Out-of-core rendering** — scene, texture, and acceleration-structure streaming for data sets larger than memory; important once OpenVDB, USD, film-resolution textures, and large meshes enter the roadmap.
+
+These are implementation strategies, not user-facing engines, so they belong under the same `RenderEngine` / render-graph umbrella as PathTracer, Rasterizer, and future GPU backends.
+
+#### 4.1.c Anti-aliasing and raster quality
 
 Anti-aliasing should be a cross-engine feature rather than a one-off rasterizer trick. The shared API is "sample pattern + reconstruction filter + resolve", with each backend choosing the parts it can implement:
 
@@ -314,7 +326,7 @@ Anti-aliasing should be a cross-engine feature rather than a one-off rasterizer 
 - **Transparency edge cases** — alpha-to-coverage, stochastic alpha, and stochastic transparency so foliage, hair, sprites, and partially transparent surfaces have an AA story.
 - **Conservative rasterization** — useful for voxelization, visibility masks, and procedural geometry; implement as its own rasterizer mode rather than folding it into ordinary MSAA.
 
-#### 4.1.c Interactive display buffers
+#### 4.1.d Interactive display buffers
 
 `RenderWidget` / Modeler currently expose progress by letting worker threads mutate a display buffer that the UI thread periodically copies into a `QImage`. That is simple and useful, but it mixes "render target" and "paintable snapshot" in one object. The long-term display pipeline should be explicit:
 
@@ -334,10 +346,12 @@ Easy wins that fill obvious gaps:
 
 - Cylinder, cone, capsule (cylinder with hemispherical caps).
 - Heightfield / terrain.
-- Signed Distance Field primitive base, with sphere-tracing intersector. Opens up procedural geometry: mandelbulbs, gyroids, fractal terrain.
+- Signed Distance Field primitive base, with sphere-tracing / distance-field ray marching intersectors. Opens up procedural geometry: mandelbulbs, gyroids, smooth-blend CSG, metaballs / blobby implicit surfaces, neural or scripted SDFs, and fractal terrain.
 - Bezier patches / NURBS — for the "all variants" pedagogy, though niche in modern pipelines.
 - Subdivision surfaces (Catmull-Clark, Loop, Doo-Sabin) — depends on `Mesh` infrastructure.
 - Particles / billboards — for sprites or fast vegetation.
+- Curve primitives — Bezier/B-spline/NURBS curves rendered as ribbons, tubes, or true curve intersections; this is the geometry side of hair/fur and stroke rendering, separate from hair shading or physics.
+- Point clouds / surfels — direct point rendering, EWA splatting, and conversion paths into meshes, SDFs, or Gaussian splats.
 
 Once tessellation lands (R4), the geometry engine can also do:
 
@@ -400,8 +414,8 @@ Layered upgrade path, but the destination is the full list:
 - **Car paint / metallic flakes** — base + flake + clearcoat model; a good stress test for layered BSDFs and material presets.
 - **Sheen / fabric BRDFs** (Charlie / ASM cloth).
 - **Hair / fur** (Marschner, Chiang).
-- **Subsurface scattering** — random-walk SSS in PT, Christensen-Burley for fast preview, BSSRDF for the textbook completeness; skin/jade/milk/wax tests.
-- **Volumetric participating media** (homogeneous + heterogeneous) — fog, smoke, clouds; Henyey-Greenstein and Mie phase functions.
+- **Subsurface scattering** — random-walk SSS in PT, Christensen-Burley for fast preview, dipole / multipole diffusion, and BSSRDF for textbook completeness; skin/jade/milk/wax tests.
+- **Volumetric participating media** (homogeneous + heterogeneous) — fog, smoke, clouds; Henyey-Greenstein and Mie phase functions. Treat the transport algorithms as first-class: ray marching for the teaching baseline, distance sampling for homogeneous media, delta / Woodcock tracking, ratio and residual-ratio tracking, null-collision estimators, spectral/decomposition tracking, transmittance estimators, and acceleration structures for heterogeneous grids.
 - **NPR shaders.** Toon/cel, Gooch (warm/cool), hatching, contour/silhouette extraction, halftone, Kuwahara. NPR is its own family — not "make the PBR pipeline look stylised" but a parallel pipeline with its own shading-normal logic.
 - **Spectral rendering** — replace RGB with wavelength sampling for correct dispersion, fluorescence, and (eventually) polarization. Big architectural change; lives at the end of this pillar.
 
@@ -455,7 +469,18 @@ Every renderer writes more than a beauty pass. AOVs are first-class outputs of t
 - Roughness, metallic, emission.
 - Sample variance (for adaptive sampling and denoise).
 
-#### 4.3.e Material library (separate from material types)
+#### 4.3.e Volumetric transport details
+
+Volumetrics are large enough to deserve an implementation plan adjacent to the BSDF work rather than a single material bullet. The minimum educational ladder:
+
+- **Homogeneous media** — analytic transmittance, exponential free-flight sampling, single scattering, and a constant-density fog scene.
+- **Heterogeneous media** — ray marching baseline, majorant grids, delta / Woodcock tracking, ratio tracking, residual-ratio tracking, and null-collision estimators compared on the same density fields.
+- **Phase functions** — isotropic, Henyey-Greenstein, Rayleigh, Mie, and artist-facing approximations for clouds/smoke.
+- **Grid acceleration** — dense grids first, then sparse/OpenVDB-style trees, brick maps, macro-cell majorants, and octree/BVH integration from §R7.
+- **Volume light transport** — next-event estimation inside media, equiangular sampling near lights, volumetric MIS, photon beams / beam radiance estimates, and volumetric photon mapping as the historical comparison.
+- **Authoring and diagnostics** — transfer-function previews, density/majorant overlays, step-count AOVs, transmittance visualizers, and rendered comparisons of bias/variance tradeoffs.
+
+#### 4.3.f Material library (separate from material types)
 
 A bundled catalog of preset materials calibrated against measured data (MERL BRDF database, Disney measured materials, Filament reference values). Gold, copper, jade, glass, rubber, brushed steel, marble, skin, pearl, silk, etc.
 
@@ -496,8 +521,9 @@ All cameras share a `Camera::generateRay(sample) → Ray` API; lens-based camera
 - **Volumetric lights / god rays** — emerge naturally from §4.3's volumetrics; called out so they aren't forgotten.
 - **IES profiles** — real-world photometric data for architectural lighting.
 - **Portal lights** — sampling helper for indirect daylight through windows.
+- **Many-light sampling systems** — light trees, alias tables, RIS / reservoir sampling, Lightcuts, virtual point lights / instant radiosity, ReGIR, and RTXDI-style direct-light reservoirs. These are the bridge between a few hand-authored lights and production scenes with thousands or millions of emitters.
 
-All require a `Light::sample(shadingPoint) → (wi, pdf, Le)` API for proper integration in MC integrators, plus a `Light::pdf(wi)` for MIS and `Light::power()` for light-tree construction.
+All require a `Light::sample(shadingPoint) → (wi, pdf, Le)` API for proper integration in MC integrators, plus a `Light::pdf(wi)` for MIS and `Light::power()` / bounded-emission metadata for light-tree construction and many-light sampling.
 
 ### 4.5 File I/O
 

--- a/docs/topics-backlog.md
+++ b/docs/topics-backlog.md
@@ -18,8 +18,10 @@ Currently scattered across §4.1 path-tracer mentions of MIS / stratified / Sobo
 - **Russian roulette and splitting.** Path termination heuristics; efficiency-optimized RR; weight windows.
 - **Path guiding.** Müller's "Practical Path Guiding" (PPG) with on-line-learned spatial mixture models. Neural path guiding (Müller 2019). Vorba et al. spatial directional mixtures.
 - **ReSTIR family.** Reservoir spatiotemporal importance resampling for direct (ReSTIR DI), global (ReSTIR GI), and full PT (ReSTIR PT). Biggest sampling breakthrough of the last several years; CPU-implementable.
-- **Manifold sampling.** Manifold next-event estimation for caustics; manifold exploration MLT.
+- **Manifold sampling.** Manifold next-event estimation (MNEE) for caustics; manifold exploration MLT.
 - **Vertex connection and merging (VCM / UPS).** Hybrid PT/photon mapping with proper MIS weighting.
+- **Progressive photon mapping variants.** SPPM, PPM, and vertex merging as historically important caustic baselines.
+- **Many-light sampling.** Lightcuts, light trees, alias tables, RIS, ReGIR, RTXDI, and reservoir-based direct-light sampling.
 
 ## B. Color science
 
@@ -41,6 +43,8 @@ Path tracing is in roadmap §4.1; the broader GI catalog is mostly absent.
 
 - **Radiosity.** Form factors (analytic, hemicube, ray-traced). Hierarchical radiosity (Hanrahan et al. 1991). Progressive shooting. Pure-Lambertian baseline; classical and pedagogically essential.
 - **Voxel cone tracing (VXGI).** Voxelize the scene, cone-trace from each shaded pixel.
+- **Lumen-style hybrid GI.** Screen traces + signed-distance-field / mesh-card traces + radiance caches; valuable as a modern real-time GI case study even if not a direct implementation target.
+- **Neural / probe radiance caches.** Neural radiance cache variants, surfel/probe caches, and temporal cache update policies.
 - **Light propagation volumes (LPV).** Spherical-harmonic per-cell radiance grids; iterative propagation.
 - **Screen-space GI (SSGI).** SSDO, SSIL, GTAO-as-GI variants.
 - **Pre-computed radiance transfer (PRT).** Spherical-harmonic transfer matrices for static geometry; live for dynamic relighting.
@@ -55,6 +59,7 @@ Implicit in the raytracer/PT today; the rasterized-shadow catalog is absent.
 - **Cascaded Shadow Maps (CSM).** Frustum-fitted cascade selection; stable cascade math; light-space cascade biasing.
 - **Shadow volumes.** Stencil-based hard shadows; "Carmack's reverse" depth-fail.
 - **Ray-traced shadow denoising.** Spatiotemporal blur, A-SVGF for soft shadow reconstruction.
+- **Virtual shadow maps.** Page/tile-based high-resolution shadow maps for large scenes; useful alongside Nanite-style virtualized geometry.
 - **Hybrid.** Irregular Z-buffer, deep shadow maps for hair/volumetric, dual-paraboloid/cubemap shadows for omnis.
 
 ## E. Differentiable & inverse rendering
@@ -93,7 +98,7 @@ Beyond §4.6.j scripted parametric and §4.3.b procedural textures.
 
 NeRF / 3DGS in §4.10 only scratches it.
 
-- **Neural denoising as a topic.** Train an OIDN-like denoiser; understand the loss functions, the AOV inputs, the training data pipeline.
+- **Neural denoising as a topic.** Train an OIDN-like denoiser; understand the loss functions, the AOV inputs, the training data pipeline. Compare against Intel OIDN, OptiX denoiser, and A-SVGF-style temporal reconstruction.
 - **Neural radiosity.** MLP per-surface representation of indirect light.
 - **Neural texture compression (NTC).** Per-asset neural decoders for ultra-compressed textures.
 - **Neural shading.** Learned BRDF approximations; learned shading models for stylized rendering.
@@ -137,15 +142,17 @@ Hosek-Wilkie is in §4.4.b; the surrounding work isn't.
 
 ## L. Anti-aliasing catalog
 
-The implementation sequence has been promoted to roadmap §4.1.a; keep this catalog here for variants that have not been pulled into active work yet.
+The implementation sequence has been promoted to roadmap §4.1.c; keep this catalog here for variants that have not been pulled into active work yet.
 
 - **Stochastic supersampling.** N samples per pixel, jittered/blue-noise distributions, reconstruction filter (see M).
 - **MSAA.** Multi-sample anti-aliasing in a rasterizer; per-fragment vs per-sample shading.
 - **Temporal AA family.** TAA (jittered camera + history reprojection), TAAU (temporal upsampling), DLAA, FXAA, SMAA (T1x/T2x/4x).
+- **Temporal super-resolution and frame generation.** DLSS / FSR / XeSS-style upscalers, optical-flow frame interpolation, and the motion-vector/history-buffer contracts they require.
 - **Morphological AA.** MLAA, SMAA-as-morphological.
 - **Conservative rasterization.** For voxelization and procedural geometry.
 - **Alpha-to-coverage.** Decoupling shading from coverage for foliage and hair.
 - **Stochastic transparency.** Hashed/stochastic alpha for unsorted transparency.
+- **Order-independent transparency (OIT).** Depth peeling, weighted blended OIT, per-pixel linked lists / A-buffer, and moment-based transparency.
 
 ## M. Reconstruction filters
 
@@ -227,6 +234,7 @@ OpenVDB read in §4.5; the rest:
 - **Iso-surface extraction.** Marching cubes (already mentioned), surface nets, dual contouring, dual marching cubes.
 - **Volume sculpt mode.** UI for editing voxel-grid representations directly (paint density, paint vector field, paint emission).
 - **Sparse volumes.** OpenVDB-style spatially sparse grid math; topology-aware operations.
+- **Volume-rendering estimators.** Delta / Woodcock tracking, ratio tracking, residual-ratio tracking, null-collision estimators, decomposition/spectral tracking, majorant-grid construction, equiangular sampling near lights, photon beams, and volumetric photon mapping.
 
 ## U. Image-processing fundamentals
 
@@ -273,6 +281,38 @@ Pillars of that future system:
 **Adjacent items already in the roadmap.** Worth coordinating with these so this doesn't fork:
 - `roadmap.md` §3.4 — Google Benchmark suite for SSE3 hot paths. Counters and benchmarks are complements, not competitors.
 - `roadmap.md` §3.7 — current perf-counter section; this backlog entry is the long-tail vision, that section is the seed.
+
+
+## W. Renderer architecture and production engine references
+
+Roadmap §4.1 names the project engines; this backlog keeps the wider implementation patterns and industry comparators from disappearing.
+
+- **Megakernel vs wavefront path tracing.** Compare simple monolithic transport against queue-based ray generation / intersection / shading / shadow / medium stages; document GPU divergence, compaction, occupancy, and CPU cache tradeoffs.
+- **Sorted and batched shading.** Material-sorted queues, texture-set batching, light-sorted next-event work, and packet/SIMD traversal beyond the first `Ray4` / `Ray8` kernels.
+- **Out-of-core rendering.** Geometry, texture, volume, and acceleration-structure paging; cache eviction; progressive refinement while data streams in.
+- **Production renderer case studies.** PBRT, Mitsuba, Cycles, RenderMan, Arnold, V-Ray, OSPRay, Embree, Hydra/Storm, and USD render delegates. The goal is not compatibility with all of them — it is to understand which architectural choices each one made and why.
+- **REYES / micropolygon pipeline.** Dicing, shading grids, displacement-heavy rendering, motion blur, and why RenderMan's historical architecture still matters pedagogically.
+- **Modern real-time engine case studies.** Nanite-style virtualized geometry, Lumen-style GI, virtual shadow maps, mesh/task shaders, bindless resources, shader permutations, and GPU-driven culling.
+- **Shader-language targets.** GLSL, HLSL, WGSL, SPIR-V, Metal Shading Language, OSL, and MaterialX as authoring/interop surfaces.
+
+## X. Implicit, point, and curve rendering
+
+Some pieces live in roadmap §4.2, but the broader field is worth tracking explicitly.
+
+- **Signed-distance-field rendering.** Sphere tracing, distance-field ray marching, smooth-min CSG, SDF fractals, procedural SDF authoring, and neural SDFs.
+- **Blobby implicit surfaces.** Metaballs, soft objects, convolution surfaces, and field composition operators.
+- **Point-based rendering.** Point clouds, surfels, EWA splatting, visibility splatting, point-set surfaces, and conversion to/from meshes or Gaussian splats.
+- **Curve and hair geometry.** Bezier/B-spline curve primitives, ribbons/tubes, true ray-curve intersections, hair acceleration structures, and raster/GPU curve rendering.
+- **Adaptive meshing.** Marching tetrahedra, dual contouring variants, adaptive octree extraction, and out-of-core meshing for large fields.
+
+## Y. Texture filtering, ray differentials, and procedural detail
+
+The roadmap has texture sources and MIP-mapping; this is the deeper sampling story.
+
+- **Ray differentials.** Footprint propagation through reflection/refraction, texture LOD for ray/path tracing, glossy footprints, and camera/lens differential initialization.
+- **Anisotropic texture filtering.** Elliptical weighted average (EWA), ripmaps, summed-area tables, and practical approximation tradeoffs.
+- **Procedural detail families.** Worley/Voronoi, Perlin/simplex, fBm, wavelet noise, Gabor noise, sparse convolution noise, texture bombing, and domain warping.
+- **Relief-style mapping.** Parallax mapping, steep parallax, parallax occlusion, relief mapping, and when they should yield to true displacement.
 
 ---
 


### PR DESCRIPTION
## Summary
- promote core gaps into the roadmap: renderer architecture patterns, volumetric transport details, richer SDF/curve/point primitive coverage, and many-light sampling
- expand the topics backlog with production renderer references, REYES/micropolygon, OIT, temporal upscaling/frame generation, implicit/point/curve rendering, ray differentials, and deeper volume estimators
- update the rasterizer-v2 plan reference after the new §4.1.b insertion shifts anti-aliasing to §4.1.c

## Validation
- `git diff --check`

Authored-by: Winston (openai-codex/gpt-5.5)

Note: the Winston GitHub App token returned 403 for pushing to this repository, so this branch/PR was pushed with the fallback personal token.
