### PR TITLE
Add OpenSCAD compile importer and mesh cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ see `docs/modernize.md` §3.11 and `CLAUDE.md` for the rules.
   `cube`, `sphere`, and `cylinder` directly into editable primitives and CSG
   objects with source-located diagnostics for unsupported syntax for Epic #234.
   — GPT-5
+- **OpenSCAD source asset import.** Registered `.scad` imports now use an
+  optional external OpenSCAD executable to compile cached STL mesh output,
+  report missing-tool diagnostics without throwing, and attach generated mesh
+  primitives for Epic #234. — GPT-5
 - **Source-backed asset scene objects.** Scene JSON can now persist
   `SourceAsset` objects with source path, importer format, import options,
   generated-output cache key, and non-fatal import diagnostics for Epic #234.

--- a/docs/markdown/appendix/c-source-map.md
+++ b/docs/markdown/appendix/c-source-map.md
@@ -23,6 +23,7 @@
 | `include/core/formats/ldraw/LDrawFileResolver.h` | [LDraw import](../tools-and-io/ldraw-import.md) |
 | `include/core/formats/ldraw/LDrawGeometryCompiler.h` | [LDraw import](../tools-and-io/ldraw-import.md) |
 | `include/core/formats/ldraw/LDrawParser.h` | [LDraw import](../tools-and-io/ldraw-import.md) |
+| `include/core/formats/stl/StlFile.h` | [Importer lifecycle](../tools-and-io/importer-lifecycle.md) |
 | `include/core/geometry/AttributeColorMap.h` | [Tessellation](../rasterization/tessellation.md) |
 | `include/core/geometry/Bresenham.h` | [Wireframe rendering](../rasterization/wireframe-rendering.md) |
 | `include/core/geometry/Curve.h` | [Tessellation](../rasterization/tessellation.md) |
@@ -158,6 +159,8 @@
 | `include/world/import/ImportResult.h` | [Importer lifecycle](../tools-and-io/importer-lifecycle.md)<br>[PLY parsing](../tools-and-io/ply-parsing.md) |
 | `include/world/import/LDrawFileSceneImporter.h` | [LDraw import](../tools-and-io/ldraw-import.md) |
 | `include/world/import/LDrawSceneImporter.h` | [LDraw import](../tools-and-io/ldraw-import.md) |
+| `include/world/import/OpenScadCompiler.h` | [Importer lifecycle](../tools-and-io/importer-lifecycle.md) |
+| `include/world/import/OpenScadSceneImporter.h` | [Importer lifecycle](../tools-and-io/importer-lifecycle.md) |
 | `include/world/import/SceneImporter.h` | [Importer lifecycle](../tools-and-io/importer-lifecycle.md)<br>[PLY parsing](../tools-and-io/ply-parsing.md) |
 | `include/world/objects/Group.h` | [Instances and motion blur](../scene-structure/instances-and-motion-blur.md)<br>[Importer lifecycle](../tools-and-io/importer-lifecycle.md) |
 | `include/world/objects/PinholeCamera.h` | [LDraw import](../tools-and-io/ldraw-import.md) |
@@ -176,6 +179,7 @@
 | `src/core/formats/ply/PlyElement.cpp` | [PLY parsing](../tools-and-io/ply-parsing.md) |
 | `src/core/formats/ply/PlyFile.cpp` | [PLY parsing](../tools-and-io/ply-parsing.md) |
 | `src/core/formats/ply/PlyProperty.cpp` | [PLY parsing](../tools-and-io/ply-parsing.md) |
+| `src/core/formats/stl/StlFile.cpp` | [Importer lifecycle](../tools-and-io/importer-lifecycle.md) |
 | `src/engine/graph/GraphRenderEngine.cpp` | [Render plans and resources](../render-graph/render-plans-and-resources.md) |
 | `src/engine/graph/PostProcessPassState.cpp` | [Render plans and resources](../render-graph/render-plans-and-resources.md) |
 | `src/engine/graph/RasterPassState.cpp` | [Render plans and resources](../render-graph/render-plans-and-resources.md) |
@@ -200,6 +204,8 @@
 | `src/widgets/world/RenderGraphTracePreviewWidget.cpp` | [Render plans and resources](../render-graph/render-plans-and-resources.md)<br>[Tools and the Modeler](../tools-and-io/tools-and-modeler.md) |
 | `src/world/import/LDrawFileSceneImporter.cpp` | [LDraw import](../tools-and-io/ldraw-import.md) |
 | `src/world/import/LDrawSceneImporter.cpp` | [LDraw import](../tools-and-io/ldraw-import.md) |
+| `src/world/import/OpenScadCompiler.cpp` | [Importer lifecycle](../tools-and-io/importer-lifecycle.md) |
+| `src/world/import/OpenScadSceneImporter.cpp` | [Importer lifecycle](../tools-and-io/importer-lifecycle.md) |
 | `src/world/objects/PinholeCamera.cpp` | [LDraw import](../tools-and-io/ldraw-import.md) |
 | `src/world/objects/Scene.cpp` | [LDraw import](../tools-and-io/ldraw-import.md) |
 | `test/fixtures/groups/` | [Instances and motion blur](../scene-structure/instances-and-motion-blur.md)<br>[Importer lifecycle](../tools-and-io/importer-lifecycle.md) |

--- a/docs/markdown/tools-and-io/importer-lifecycle.md
+++ b/docs/markdown/tools-and-io/importer-lifecycle.md
@@ -67,6 +67,17 @@ for caches and provenance. If resolution fails, convert `AssetResolutionError`
 into an import error diagnostic that includes the requested path and searched
 roots instead of letting the exception escape without context.
 
+## Generated Outputs
+
+Some importers call external authoring tools before they can return renderer
+geometry. [`OpenScadSceneImporter`](../../../include/world/import/OpenScadSceneImporter.h)
+is the template: it asks
+[`OpenScadCompiler`](../../../include/world/import/OpenScadCompiler.h) to locate
+the optional `openscad` executable, compile the source into a generated STL
+mesh, and cache that output by source contents plus import options. Missing
+executables are reported as warnings with an empty imported group so a scene can
+still load; failed tool runs or malformed generated meshes are errors.
+
 ## Diagnostics
 
 [`ImportDiagnostic`](../../../include/world/import/ImportDiagnostic.h) is for
@@ -179,7 +190,13 @@ visible with the ghost material. The flags do not edit the saved scene.
 - `include/world/objects/Group.h`
 - `include/world/objects/StepVisibilityEvaluator.h`
 - `include/core/formats/AssetResolver.h`
+- `include/core/formats/stl/StlFile.h`
+- `include/world/import/OpenScadCompiler.h`
+- `include/world/import/OpenScadSceneImporter.h`
 - `src/core/formats/AssetResolver.cpp`
+- `src/core/formats/stl/StlFile.cpp`
+- `src/world/import/OpenScadCompiler.cpp`
+- `src/world/import/OpenScadSceneImporter.cpp`
 - `test/helpers/ImporterTestHelper.h`
 - `test/helpers/ImporterTestHelper.cpp`
 - `test/fixtures/groups/`

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -538,7 +538,11 @@ Read and write wherever it's reasonable. The guiding rule: if a format is used a
 - **OpenVDB** — volumetric grids, once §4.3 volumetrics land. Read-only initially.
 - **EXR** — float HDR output from the framebuffer (R1) and environment map input. Read + write via OpenEXR or tinyexr.
 - **HDR (Radiance `.hdr`)** — environment maps. Read.
-- **OpenSCAD `.scad`** — see §4.6 scripted objects.
+- **OpenSCAD `.scad`** — ~~external CLI compile adapter with missing-tool
+  diagnostics and generated mesh caching~~ ✅ **Done.** `OpenScadSceneImporter`
+  compiles `.scad` sources through an optional OpenSCAD executable into cached
+  STL mesh output for Epic #234; native scripted-object authoring remains in
+  §4.6.
 - **LDraw `.dat` / `.ldr`** — LEGO part and model text format. ~~Core line
   parser for command types 0 through 5.~~ ✅ **Done.** `core/formats/ldraw`
   preserves meta commands, subfile filenames, and geometry records for #210;

--- a/include/core/formats/stl/StlFile.h
+++ b/include/core/formats/stl/StlFile.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "core/Exception.h"
+
+#include <iosfwd>
+#include <string>
+
+class Mesh;
+
+class StlParseError : public Exception {
+public:
+  inline explicit StlParseError(const std::string& message, const std::string& file, int line)
+      : Exception(message, file, line) {
+  }
+};
+
+class StlFile {
+public:
+  explicit StlFile(std::istream& input, Mesh& mesh);
+
+  void read(std::istream& input, Mesh& mesh);
+};

--- a/include/world/import/OpenScadCompiler.h
+++ b/include/world/import/OpenScadCompiler.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include "world/import/ImportDiagnostic.h"
+
+#include <QJsonObject>
+#include <QString>
+#include <QStringList>
+
+#include <optional>
+#include <vector>
+
+namespace world {
+
+  struct OpenScadCompileRequest {
+    QString sourcePath;
+    QString executablePath;
+    QString cacheDirectory;
+    QJsonObject options;
+  };
+
+  struct OpenScadCompileResult {
+    bool succeeded{false};
+    bool cacheHit{false};
+    QString outputPath;
+    QString cacheKey;
+    std::vector<ImportDiagnostic> diagnostics;
+  };
+
+  class OpenScadProcess {
+  public:
+    virtual ~OpenScadProcess();
+
+    [[nodiscard]] virtual int run(const QString& executable, const QStringList& arguments,
+                                  const QString& workingDirectory, QString* standardOutput,
+                                  QString* standardError) const;
+  };
+
+  class OpenScadCompiler {
+  public:
+    explicit OpenScadCompiler(const OpenScadProcess* process = nullptr);
+
+    [[nodiscard]] OpenScadCompileResult compile(const OpenScadCompileRequest& request) const;
+
+    [[nodiscard]] static std::optional<QString> findExecutable(const QString& overridePath);
+    [[nodiscard]] static QString cacheKeyFor(const QString& sourcePath, const QJsonObject& options);
+    [[nodiscard]] static QString defaultCacheDirectory();
+
+  private:
+    const OpenScadProcess* m_process;
+  };
+
+}

--- a/include/world/import/OpenScadSceneImporter.h
+++ b/include/world/import/OpenScadSceneImporter.h
@@ -6,8 +6,10 @@ namespace world {
 
   /**
     * Imports a deliberately small native OpenSCAD subset into editable world
-    * primitives and CSG nodes. Supported constructs are translate, rotate,
-    * scale, union, difference, intersection, cube, sphere, and cylinder.
+    * primitives and CSG nodes by default, or compiles through OpenSCAD when
+    * compile import options are supplied. Supported native constructs are
+    * translate, rotate, scale, union, difference, intersection, cube, sphere,
+    * and cylinder.
     */
   class OpenScadSceneImporter : public SceneImporter {
   public:

--- a/src/core/formats/stl/StlFile.cpp
+++ b/src/core/formats/stl/StlFile.cpp
@@ -1,0 +1,130 @@
+#include "core/formats/stl/StlFile.h"
+
+#include "core/geometry/Mesh.h"
+
+#include <array>
+#include <cstdint>
+#include <cstring>
+#include <fstream>
+#include <istream>
+#include <limits>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace {
+  float readFloat32(const char* bytes) {
+    float value;
+    std::memcpy(&value, bytes, sizeof(float));
+    return value;
+  }
+
+  std::uint32_t readUInt32LE(const char* bytes) {
+    return static_cast<std::uint32_t>(static_cast<unsigned char>(bytes[0])) |
+           (static_cast<std::uint32_t>(static_cast<unsigned char>(bytes[1])) << 8u) |
+           (static_cast<std::uint32_t>(static_cast<unsigned char>(bytes[2])) << 16u) |
+           (static_cast<std::uint32_t>(static_cast<unsigned char>(bytes[3])) << 24u);
+  }
+
+  Vector3d vectorFrom(const char* bytes) {
+    return Vector3d(readFloat32(bytes), readFloat32(bytes + 4), readFloat32(bytes + 8));
+  }
+
+  void addTriangle(Mesh& mesh, const Vector3d& normal, const std::array<Vector3d, 3>& vertices) {
+    const int offset = static_cast<int>(mesh.vertices().size());
+    mesh.addVertex(vertices[0], normal);
+    mesh.addVertex(vertices[1], normal);
+    mesh.addVertex(vertices[2], normal);
+    mesh.addFace({offset, offset + 1, offset + 2});
+  }
+
+  bool tryReadBinary(const std::string& bytes, Mesh& mesh) {
+    if (bytes.size() < 84)
+      return false;
+
+    const std::uint32_t triangleCount = readUInt32LE(bytes.data() + 80);
+    const std::uint64_t expectedSize = 84ull + 50ull * triangleCount;
+    if (expectedSize != bytes.size())
+      return false;
+
+    for (std::uint32_t i = 0; i != triangleCount; ++i) {
+      const char* triangle = bytes.data() + 84 + 50 * i;
+      const Vector3d normal = vectorFrom(triangle);
+      std::array<Vector3d, 3> vertices = {
+        vectorFrom(triangle + 12),
+        vectorFrom(triangle + 24),
+        vectorFrom(triangle + 36),
+      };
+      addTriangle(mesh, normal, vertices);
+    }
+    return true;
+  }
+
+  bool readVector(std::istream& input, Vector3d* vector) {
+    double x;
+    double y;
+    double z;
+    if (!(input >> x >> y >> z))
+      return false;
+    *vector = Vector3d(x, y, z);
+    return true;
+  }
+
+  void expectToken(std::istream& input, const std::string& expected) {
+    std::string token;
+    if (!(input >> token) || token != expected) {
+      throw StlParseError("Invalid ASCII STL: expected '" + expected + "'", __FILE__, __LINE__);
+    }
+  }
+
+  void readAscii(const std::string& bytes, Mesh& mesh) {
+    std::istringstream input(bytes);
+    expectToken(input, "solid");
+    input.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
+
+    std::string token;
+    while (input >> token) {
+      if (token == "endsolid")
+        return;
+      if (token != "facet")
+        throw StlParseError("Invalid ASCII STL: expected facet", __FILE__, __LINE__);
+
+      expectToken(input, "normal");
+      Vector3d normal;
+      if (!readVector(input, &normal))
+        throw StlParseError("Invalid ASCII STL: malformed facet normal", __FILE__, __LINE__);
+
+      expectToken(input, "outer");
+      expectToken(input, "loop");
+
+      std::array<Vector3d, 3> vertices;
+      for (auto& vertex : vertices) {
+        expectToken(input, "vertex");
+        if (!readVector(input, &vertex))
+          throw StlParseError("Invalid ASCII STL: malformed vertex", __FILE__, __LINE__);
+      }
+
+      expectToken(input, "endloop");
+      expectToken(input, "endfacet");
+      addTriangle(mesh, normal, vertices);
+    }
+
+    throw StlParseError("Invalid ASCII STL: missing endsolid", __FILE__, __LINE__);
+  }
+}
+
+StlFile::StlFile(std::istream& input, Mesh& mesh) {
+  read(input, mesh);
+}
+
+void StlFile::read(std::istream& input, Mesh& mesh) {
+  const std::string bytes((std::istreambuf_iterator<char>(input)),
+                          std::istreambuf_iterator<char>());
+  if (bytes.empty())
+    throw StlParseError("Invalid STL: empty file", __FILE__, __LINE__);
+
+  if (tryReadBinary(bytes, mesh))
+    return;
+
+  readAscii(bytes, mesh);
+}

--- a/src/world/import/OpenScadCompiler.cpp
+++ b/src/world/import/OpenScadCompiler.cpp
@@ -1,0 +1,148 @@
+#include "world/import/OpenScadCompiler.h"
+
+#include <QCryptographicHash>
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QJsonDocument>
+#include <QProcess>
+#include <QStandardPaths>
+
+namespace {
+  QJsonObject cacheIdentityOptions(QJsonObject options) {
+    options.remove("executable");
+    options.remove("cacheDirectory");
+    return options;
+  }
+
+  QStringList argumentsFor(const QString& outputPath, const QString& sourcePath,
+                           const QJsonObject& options) {
+    QStringList arguments;
+    arguments << "-o" << outputPath;
+
+    const auto defines = options.value("define").toObject();
+    for (auto it = defines.begin(); it != defines.end(); ++it) {
+      arguments << "-D" << QString("%1=%2").arg(it.key(), it.value().toVariant().toString());
+    }
+
+    arguments << sourcePath;
+    return arguments;
+  }
+}
+
+namespace world {
+
+  OpenScadProcess::~OpenScadProcess() = default;
+
+  int OpenScadProcess::run(const QString& executable, const QStringList& arguments,
+                           const QString& workingDirectory, QString* standardOutput,
+                           QString* standardError) const {
+    QProcess process;
+    process.setProgram(executable);
+    process.setArguments(arguments);
+    if (!workingDirectory.isEmpty())
+      process.setWorkingDirectory(workingDirectory);
+    process.start();
+    if (!process.waitForStarted()) {
+      if (standardError)
+        *standardError = process.errorString();
+      return -1;
+    }
+    process.waitForFinished(-1);
+    if (standardOutput)
+      *standardOutput = QString::fromLocal8Bit(process.readAllStandardOutput());
+    if (standardError)
+      *standardError = QString::fromLocal8Bit(process.readAllStandardError());
+    return process.exitStatus() == QProcess::NormalExit ? process.exitCode() : -1;
+  }
+
+  OpenScadCompiler::OpenScadCompiler(const OpenScadProcess* process)
+      : m_process(process) {
+  }
+
+  OpenScadCompileResult OpenScadCompiler::compile(const OpenScadCompileRequest& request) const {
+    OpenScadCompileResult result;
+    result.cacheKey = cacheKeyFor(request.sourcePath, request.options);
+
+    const QString cacheDirectory =
+      request.cacheDirectory.trimmed().isEmpty() ? defaultCacheDirectory() : request.cacheDirectory;
+    QDir().mkpath(cacheDirectory);
+    result.outputPath = QDir(cacheDirectory).filePath(result.cacheKey + ".stl");
+
+    if (QFileInfo::exists(result.outputPath)) {
+      result.succeeded = true;
+      result.cacheHit = true;
+      return result;
+    }
+
+    const std::optional<QString> executable = findExecutable(request.executablePath);
+    if (!executable) {
+      result.diagnostics.push_back(ImportDiagnostic::warning(
+        "OpenSCAD executable was not found; install openscad or set the executable import option",
+        request.sourcePath));
+      return result;
+    }
+
+    const OpenScadProcess defaultProcess;
+    const OpenScadProcess& process = m_process ? *m_process : defaultProcess;
+    QString standardOutput;
+    QString standardError;
+    const int exitCode =
+      process.run(*executable, argumentsFor(result.outputPath, request.sourcePath, request.options),
+                  QFileInfo(request.sourcePath).absolutePath(), &standardOutput, &standardError);
+    if (exitCode != 0) {
+      const QString detail =
+        standardError.trimmed().isEmpty() ? standardOutput.trimmed() : standardError.trimmed();
+      result.diagnostics.push_back(ImportDiagnostic::error(
+        detail.isEmpty()
+          ? QString("OpenSCAD failed with exit code %1").arg(exitCode)
+          : QString("OpenSCAD failed with exit code %1: %2").arg(exitCode).arg(detail),
+        request.sourcePath));
+      QFile::remove(result.outputPath);
+      return result;
+    }
+
+    if (!QFileInfo::exists(result.outputPath)) {
+      result.diagnostics.push_back(ImportDiagnostic::error(
+        "OpenSCAD completed without producing a mesh output", request.sourcePath));
+      return result;
+    }
+
+    result.succeeded = true;
+    result.cacheHit = false;
+    return result;
+  }
+
+  std::optional<QString> OpenScadCompiler::findExecutable(const QString& overridePath) {
+    if (!overridePath.trimmed().isEmpty()) {
+      const QFileInfo info(overridePath);
+      if (info.exists() && info.isExecutable())
+        return info.absoluteFilePath();
+      return std::nullopt;
+    }
+
+    const QString executable = QStandardPaths::findExecutable("openscad");
+    if (executable.isEmpty())
+      return std::nullopt;
+    return executable;
+  }
+
+  QString OpenScadCompiler::cacheKeyFor(const QString& sourcePath, const QJsonObject& options) {
+    QFile file(sourcePath);
+    QCryptographicHash hash(QCryptographicHash::Sha256);
+    if (file.open(QIODevice::ReadOnly))
+      hash.addData(&file);
+    else
+      hash.addData(sourcePath.toUtf8());
+    hash.addData(QJsonDocument(cacheIdentityOptions(options)).toJson(QJsonDocument::Compact));
+    return QString::fromLatin1(hash.result().toHex());
+  }
+
+  QString OpenScadCompiler::defaultCacheDirectory() {
+    QString location = QStandardPaths::writableLocation(QStandardPaths::CacheLocation);
+    if (location.isEmpty())
+      location = QDir::temp().filePath("raytracer-cache");
+    return QDir(location).filePath("openscad");
+  }
+
+}

--- a/src/world/import/OpenScadSceneImporter.cpp
+++ b/src/world/import/OpenScadSceneImporter.cpp
@@ -1,8 +1,13 @@
 #include "world/import/OpenScadSceneImporter.h"
 
+#include "core/formats/stl/StlFile.h"
+#include "core/geometry/Mesh.h"
 #include "core/math/Angle.h"
+#include "render/primitives/MeshPrimitive.h"
+#include "world/import/OpenScadCompiler.h"
 #include "world/import/SceneImporterRegistry.h"
 #include "world/objects/Box.h"
+#include "world/objects/CompiledPrimitive.h"
 #include "world/objects/Cylinder.h"
 #include "world/objects/Difference.h"
 #include "world/objects/Group.h"
@@ -16,6 +21,7 @@
 #include <algorithm>
 #include <array>
 #include <cmath>
+#include <fstream>
 #include <memory>
 #include <optional>
 #include <utility>
@@ -636,6 +642,11 @@ namespace {
     std::size_t m_index{0};
     std::vector<world::ImportDiagnostic> m_diagnostics;
   };
+
+  bool hasCompileOptions(const world::ImportOptions& options) {
+    return options.contains("executable") || options.contains("cacheDirectory") ||
+           options.contains("define");
+  }
 }
 
 namespace world {
@@ -649,27 +660,120 @@ namespace world {
   }
 
   ImportOptionSchemas OpenScadSceneImporter::optionSchema() const {
-    return {};
+    return {
+      {"executable",
+       ImportOptionType::FilePath,
+       "OpenSCAD executable",
+       "Path to the openscad executable. When empty, PATH is searched.",
+       "",
+       false,
+       {}},
+      {"cacheDirectory",
+       ImportOptionType::DirectoryPath,
+       "Generated mesh cache",
+       "Directory for generated STL meshes keyed by source content and import options.",
+       "",
+       false,
+       {}},
+      {"define",
+       ImportOptionType::String,
+       "OpenSCAD definitions",
+       "JSON object of -D name=value definitions passed to OpenSCAD.",
+       "",
+       false,
+       {}},
+    };
   }
 
   ImportResult OpenScadSceneImporter::importFile(const QString& filename,
-                                                 const ImportOptions&) const {
-    ImportSourceMetadata source;
-    source.importerName = name();
-    source.formatName = "OpenSCAD subset";
-    source.sourcePath = filename;
-    source.properties = {{"nativeSubset", true}};
+                                                 const ImportOptions& options) const {
+    if (!hasCompileOptions(options)) {
+      ImportSourceMetadata source;
+      source.importerName = name();
+      source.formatName = "OpenSCAD subset";
+      source.sourcePath = filename;
+      source.properties = {{"nativeSubset", true}};
 
-    QFile file(filename);
-    if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) {
-      return ImportResult::failed(
-        {ImportDiagnostic::error("Unable to read import source", filename)}, source);
+      QFile file(filename);
+      if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) {
+        return ImportResult::failed(
+          {ImportDiagnostic::error("Unable to read import source", filename)}, source);
+      }
+
+      std::vector<ImportDiagnostic> diagnostics;
+      Lexer lexer(QString::fromUtf8(file.readAll()));
+      auto tokens = lexer.lex(diagnostics, filename);
+      return Parser(std::move(tokens), filename).parse(std::move(diagnostics));
     }
 
-    std::vector<ImportDiagnostic> diagnostics;
-    Lexer lexer(QString::fromUtf8(file.readAll()));
-    auto tokens = lexer.lex(diagnostics, filename);
-    return Parser(std::move(tokens), filename).parse(std::move(diagnostics));
+    ImportSourceMetadata source;
+    source.importerName = name();
+    source.formatName = "OpenSCAD";
+    source.sourcePath = filename;
+
+    OpenScadCompileRequest request;
+    request.sourcePath = filename;
+    request.executablePath = options.value("executable").toString();
+    request.cacheDirectory = options.value("cacheDirectory").toString();
+    request.options = options.values();
+
+    const OpenScadCompiler compiler;
+    OpenScadCompileResult compiled = compiler.compile(request);
+    source.properties = {
+      {"generatedOutputCacheKey", compiled.cacheKey},
+      {"generatedOutputPath", compiled.outputPath},
+      {"generatedOutputCacheHit", compiled.cacheHit},
+    };
+
+    if (!compiled.succeeded) {
+      const bool hasOnlyWarnings =
+        !compiled.diagnostics.empty() &&
+        std::all_of(compiled.diagnostics.begin(), compiled.diagnostics.end(),
+                    [](const ImportDiagnostic& diagnostic) { return diagnostic.isWarning(); });
+      if (hasOnlyWarnings) {
+        auto group = std::make_unique<Group>();
+        group->setName(QFileInfo(filename).baseName());
+        ImportResult result(std::move(group), source);
+        for (const auto& diagnostic : compiled.diagnostics)
+          result.addDiagnostic(diagnostic);
+        return result;
+      }
+      return ImportResult::failed(std::move(compiled.diagnostics), source);
+    }
+
+    Mesh mesh;
+    std::ifstream input(compiled.outputPath.toStdString(), std::ios::binary);
+    if (!input) {
+      return ImportResult::failed(
+        {ImportDiagnostic::error("Unable to read generated OpenSCAD mesh", compiled.outputPath)},
+        source);
+    }
+
+    try {
+      StlFile stl(input, mesh);
+    } catch (const std::exception& error) {
+      return ImportResult::failed(
+        {ImportDiagnostic::error(
+          QString("Unable to parse generated OpenSCAD mesh: %1").arg(error.what()),
+          compiled.outputPath)},
+        source);
+    }
+
+    auto group = std::make_unique<Group>();
+    group->setName(QFileInfo(filename).baseName());
+
+    auto primitive = std::make_shared<render::MeshPrimitive>(
+      std::move(mesh), render::MeshPrimitive::NormalMode::Flat);
+    auto compiledPrimitive = std::make_unique<CompiledPrimitive>(primitive);
+    compiledPrimitive->setName("OpenSCAD Mesh");
+    group->addChild(std::move(compiledPrimitive));
+
+    ImportResult result(std::move(group), source);
+    if (compiled.cacheHit) {
+      result.addDiagnostic(
+        ImportDiagnostic::warning("Reused cached OpenSCAD mesh output", compiled.outputPath));
+    }
+    return result;
   }
 
 }

--- a/src/world/objects/SourceAsset.cpp
+++ b/src/world/objects/SourceAsset.cpp
@@ -118,6 +118,11 @@ void SourceAsset::rebuildGeneratedChildren() {
   }
 
   world::ImportResult result = importer->importFile(source, world::ImportOptions(m_importOptions));
+  const QString generatedOutputCacheKey =
+    result.source().properties.value("generatedOutputCacheKey").toString();
+  if (!generatedOutputCacheKey.isEmpty())
+    setGeneratedOutputCacheKey(generatedOutputCacheKey);
+
   for (const auto& diagnostic : result.diagnostics()) {
     addDiagnostic(diagnostic);
   }

--- a/test/fixtures/importers/openscad/simple.scad
+++ b/test/fixtures/importers/openscad/simple.scad
@@ -1,0 +1,1 @@
+cube([1, 1, 1], center = true);

--- a/test/unit/core/formats/stl/StlFileTest.cpp
+++ b/test/unit/core/formats/stl/StlFileTest.cpp
@@ -1,0 +1,35 @@
+#include "core/formats/stl/StlFile.h"
+
+#include "core/geometry/Mesh.h"
+
+#include <gtest/gtest.h>
+
+#include <sstream>
+
+namespace StlFileTest {
+  TEST(StlFile, ReadsAsciiTriangleMesh) {
+    std::istringstream input("solid fixture\n"
+                             "  facet normal 0 0 1\n"
+                             "    outer loop\n"
+                             "      vertex 0 0 0\n"
+                             "      vertex 1 0 0\n"
+                             "      vertex 0 1 0\n"
+                             "    endloop\n"
+                             "  endfacet\n"
+                             "endsolid fixture\n");
+
+    Mesh mesh;
+    StlFile file(input, mesh);
+
+    EXPECT_EQ(3u, mesh.vertices().size());
+    ASSERT_EQ(1u, mesh.faces().size());
+    EXPECT_EQ((Mesh::Face{0, 1, 2}), mesh.faces()[0]);
+  }
+
+  TEST(StlFile, RejectsMalformedAsciiStl) {
+    std::istringstream input("solid broken\nfacet normal 0 0 1\nendsolid broken\n");
+    Mesh mesh;
+
+    EXPECT_THROW(StlFile file(input, mesh), StlParseError);
+  }
+}

--- a/test/unit/world/import/OpenScadSceneImporterTest.cpp
+++ b/test/unit/world/import/OpenScadSceneImporterTest.cpp
@@ -1,21 +1,31 @@
 #include <gtest/gtest.h>
 
+#include "core/geometry/Mesh.h"
 #include "render/primitives/Composite.h"
 #include "render/primitives/Difference.h"
 #include "render/primitives/Instance.h"
+#include "render/primitives/MeshPrimitive.h"
 #include "render/primitives/Primitive.h"
 #include "render/primitives/Scene.h"
 #include "world/import/OpenScadSceneImporter.h"
 #include "world/import/SceneImporterRegistry.h"
 #include "world/objects/Box.h"
+#include "world/objects/CompiledPrimitive.h"
 #include "world/objects/Cylinder.h"
 #include "world/objects/Difference.h"
 #include "world/objects/Group.h"
 #include "world/objects/Intersection.h"
+#include "world/objects/SourceAsset.h"
 #include "world/objects/Sphere.h"
 #include "world/objects/Union.h"
 
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QJsonObject>
+#include <QTemporaryDir>
 #include <QTemporaryFile>
+#include <QTextStream>
 
 #include <cmath>
 #include <memory>
@@ -46,10 +56,62 @@ namespace OpenScadSceneImporterTest {
       }
       return false;
     }
+
+    const char* fakeOpenScadScript() {
+      return R"SH(#!/bin/sh
+out=""
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "-o" ]; then
+    shift
+    out="$1"
+  fi
+  shift
+done
+echo run >> "$OPENSCAD_FAKE_LOG"
+cat > "$out" <<'STL'
+solid openscad
+  facet normal 0 0 1
+    outer loop
+      vertex 0 0 0
+      vertex 1 0 0
+      vertex 0 1 0
+    endloop
+  endfacet
+endsolid openscad
+STL
+exit 0
+)SH";
+    }
+
+    QString writeExecutable(QTemporaryDir& dir) {
+      const QString path = dir.filePath("openscad-fake");
+      QFile file(path);
+      EXPECT_TRUE(file.open(QIODevice::WriteOnly | QIODevice::Truncate));
+      file.write(fakeOpenScadScript());
+      file.close();
+      EXPECT_TRUE(QFile::setPermissions(path, QFileDevice::ReadOwner | QFileDevice::WriteOwner |
+                                                QFileDevice::ExeOwner));
+      return path;
+    }
+
+    QString sourceFixture() {
+      return QStringLiteral("test/fixtures/importers/openscad/simple.scad");
+    }
+
+    QJsonObject optionsFor(const QString& executable, const QString& cacheDirectory) {
+      return QJsonObject{{"executable", executable}, {"cacheDirectory", cacheDirectory}};
+    }
+
+    int logRunCount(const QString& path) {
+      QFile file(path);
+      if (!file.open(QIODevice::ReadOnly))
+        return 0;
+      return QString::fromUtf8(file.readAll()).split('\n', Qt::SkipEmptyParts).size();
+    }
   }
 
-  TEST(OpenScadSceneImporter, IsRegisteredForScadFiles) {
-    auto importer = world::SceneImporterRegistry::self().createForFile("fixture.scad");
+  TEST(OpenScadSceneImporter, RegistersForScadFiles) {
+    auto importer = world::SceneImporterRegistry::self().createForFile("part.scad");
 
     ASSERT_NE(nullptr, importer);
     EXPECT_EQ(QString("openscad"), importer->name());
@@ -170,5 +232,94 @@ namespace OpenScadSceneImporterTest {
     EXPECT_EQ(path, diagnostic.source);
     EXPECT_EQ(2, diagnostic.line);
     EXPECT_EQ(3, diagnostic.column);
+  }
+
+  TEST(OpenScadSceneImporter, ReportsMissingExecutableAsNonFatalDiagnostic) {
+    world::OpenScadSceneImporter importer;
+
+    const auto result = importer.importFile(
+      sourceFixture(),
+      world::ImportOptions(QJsonObject{{"executable", "/definitely/missing/openscad"}}));
+
+    EXPECT_TRUE(result.succeeded());
+    ASSERT_NE(nullptr, result.groupRoot());
+    EXPECT_TRUE(result.groupRoot()->childElements().empty());
+    ASSERT_EQ(1u, result.diagnostics().size());
+    EXPECT_TRUE(result.diagnostics()[0].isWarning());
+    EXPECT_TRUE(result.diagnostics()[0].message.contains("OpenSCAD executable was not found"));
+  }
+
+  TEST(OpenScadSceneImporter, CompilesScadFixtureIntoMeshPrimitive) {
+    QTemporaryDir dir;
+    const QString executable = writeExecutable(dir);
+    const QString cacheDirectory = dir.filePath("cache");
+    qputenv("OPENSCAD_FAKE_LOG", dir.filePath("openscad.log").toLocal8Bit());
+
+    world::OpenScadSceneImporter importer;
+    const auto result = importer.importFile(
+      sourceFixture(), world::ImportOptions(optionsFor(executable, cacheDirectory)));
+
+    EXPECT_TRUE(result.succeeded());
+    ASSERT_NE(nullptr, result.groupRoot());
+    ASSERT_EQ(1, result.groupRoot()->childElements().size());
+    auto* compiled = qobject_cast<CompiledPrimitive*>(result.groupRoot()->childElements().front());
+    ASSERT_NE(nullptr, compiled);
+    auto primitive =
+      std::dynamic_pointer_cast<render::MeshPrimitive>(compiled->toRaytracerPrimitive());
+    ASSERT_NE(nullptr, primitive);
+    ASSERT_NE(nullptr, primitive->mesh());
+    EXPECT_EQ(3u, primitive->mesh()->vertices().size());
+    EXPECT_EQ(1u, primitive->mesh()->faces().size());
+    EXPECT_TRUE(QFileInfo::exists(result.source().properties["generatedOutputPath"].toString()));
+    EXPECT_FALSE(result.source().properties["generatedOutputCacheKey"].toString().isEmpty());
+  }
+
+  TEST(OpenScadSceneImporter, CachesGeneratedOutputBySourceAndOptionsIdentity) {
+    QTemporaryDir dir;
+    const QString executable = writeExecutable(dir);
+    const QString cacheDirectory = dir.filePath("cache");
+    const QString logPath = dir.filePath("openscad.log");
+    qputenv("OPENSCAD_FAKE_LOG", logPath.toLocal8Bit());
+
+    world::OpenScadSceneImporter importer;
+    const auto first = importer.importFile(
+      sourceFixture(), world::ImportOptions(optionsFor(executable, cacheDirectory)));
+    const auto second = importer.importFile(
+      sourceFixture(), world::ImportOptions(optionsFor(executable, cacheDirectory)));
+
+    EXPECT_TRUE(first.succeeded());
+    EXPECT_TRUE(second.succeeded());
+    EXPECT_EQ(1, logRunCount(logPath));
+    EXPECT_EQ(first.source().properties["generatedOutputCacheKey"].toString(),
+              second.source().properties["generatedOutputCacheKey"].toString());
+    ASSERT_EQ(1u, second.diagnostics().size());
+    EXPECT_TRUE(second.diagnostics()[0].message.contains("Reused cached OpenSCAD mesh output"));
+
+    QJsonObject changedOptions = optionsFor(executable, cacheDirectory);
+    changedOptions["define"] = QJsonObject{{"teeth", 12}};
+    const auto changed = importer.importFile(sourceFixture(), world::ImportOptions(changedOptions));
+
+    EXPECT_TRUE(changed.succeeded());
+    EXPECT_EQ(2, logRunCount(logPath));
+    EXPECT_NE(first.source().properties["generatedOutputCacheKey"].toString(),
+              changed.source().properties["generatedOutputCacheKey"].toString());
+  }
+
+  TEST(SourceAsset, StoresOpenScadGeneratedOutputCacheKeyAfterRebuild) {
+    QTemporaryDir dir;
+    const QString executable = writeExecutable(dir);
+    const QString cacheDirectory = dir.filePath("cache");
+    qputenv("OPENSCAD_FAKE_LOG", dir.filePath("openscad.log").toLocal8Bit());
+
+    SourceAsset asset;
+    asset.setSourcePath(sourceFixture());
+    asset.setFormat("openscad");
+    asset.setImportOptions(optionsFor(executable, cacheDirectory));
+
+    asset.rebuildGeneratedChildren();
+
+    EXPECT_TRUE(asset.diagnostics().empty());
+    EXPECT_FALSE(asset.generatedOutputCacheKey().isEmpty());
+    ASSERT_EQ(1, asset.childElements().size());
   }
 }


### PR DESCRIPTION
Closes #268

Use OpenSCAD-authored `.scad` files as source-backed assets without making the external tool a hard runtime dependency. Missing executables now produce a clear non-fatal import diagnostic, while successful compiles produce cached generated mesh output keyed by source contents and import options.

Added a registered OpenSCAD scene importer, an OpenSCAD process/cache adapter, STL mesh loading for generated output, and `SourceAsset` cache-key persistence. Tests use a fake executable so CI isolates the external-tool dependency while covering missing-tool diagnostics, fixture compilation, cache reuse, and generated-output adoption.

---
*Authored by Codex (trigger=initial). Review carefully.*<!-- syrus-cost-footer:start -->
This PR was implemented by Syrus across 9 Runs at a total cost of $0.00.
<!-- syrus-cost-footer:end -->